### PR TITLE
feat: add node.js v24 to CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.x, 23.x]
+        node-version: [22.x, 23.x, 24.x]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Adds Node.js v24.x to the testing matrix in the Node.js CI workflow. This will ensure that your project is tested against the latest Node.js LTS version.